### PR TITLE
Python kit: allow an empty action list

### DIFF
--- a/kits/python/simple/main.py
+++ b/kits/python/simple/main.py
@@ -33,5 +33,6 @@ if __name__ == "__main__":
             observation["updates"] = []
             step += 1
             observation["step"] = step
-            print(",".join(actions))
+            if actions:
+                print(",".join(actions))
             print("D_FINISH")


### PR DESCRIPTION
If a player submits no actions (eg because all units on cooldown), currently python will raise an exception. This change would skip printing if there are no actions.