### PR TITLE
Fix memory leaks

### DIFF
--- a/kits/cpp/simple-transpiled/lux/city.hpp
+++ b/kits/cpp/simple-transpiled/lux/city.hpp
@@ -52,22 +52,14 @@ namespace lux
         string cityid;
         int team;
         float fuel;
-        vector<CityTile *> citytiles;
+        vector<CityTile> citytiles{};
         float lightUpkeep;
         City(){};
-        City(int teamid, const string &cityid, float fuel, float lightUpkeep)
-        {
-            this->cityid = cityid;
-            this->team = teamid;
-            this->fuel = fuel;
-            this->citytiles = vector<CityTile *>();
-            this->lightUpkeep = lightUpkeep;
-        }
+        City(int teamid, const string &cityid, float fuel, float lightUpkeep) : cityid(cityid), team(teamid), fuel(fuel), lightUpkeep(lightUpkeep) {}
         CityTile* addCityTile(int x, int y, int cooldown)
         {
-            CityTile* ct = new CityTile(this->team, this->cityid, x, y, cooldown);
-            this->citytiles.push_back(ct);
-            return ct;
+            citytiles.emplace_back(team, cityid, x, y, cooldown);
+            return &citytiles.back();
         }
         float getLightUpkeep()
         {

--- a/kits/cpp/simple-transpiled/lux/game_objects.hpp
+++ b/kits/cpp/simple-transpiled/lux/game_objects.hpp
@@ -101,16 +101,11 @@ namespace lux
     public:
         int researchPoints = 0;
         int team = -1;
-        vector<Unit> units;
-        map<string, City *> cities;
+        vector<Unit> units{};
+        map<string, City> cities{};
         int cityTileCount = 0;
         Player(){};
-        Player(int team_id)
-        {
-            team = team_id;
-            cities = map<string, City *>();
-            units = vector<Unit>();
-        };
+        Player(int team_id) : team(team_id) {}
         bool researchedCoal()
         {
             return this->researchPoints >= (int)GAME_CONSTANTS["PARAMETERS"]["RESEARCH_REQUIREMENTS"]["COAL"];

--- a/kits/cpp/simple-transpiled/lux/kit.hpp
+++ b/kits/cpp/simple-transpiled/lux/kit.hpp
@@ -140,7 +140,7 @@ namespace kit
                     string cityid = updates[i++];
                     float fuel = stof(updates[i++]);
                     float lightUpkeep = stof(updates[i++]);
-                    this->players[team].cities[cityid] = new lux::City(team, cityid, fuel, lightUpkeep);
+                    this->players[team].cities[cityid] = lux::City(team, cityid, fuel, lightUpkeep);
                 }
                 else if (input_identifier == INPUT_CONSTANTS::CITY_TILES)
                 {
@@ -150,7 +150,7 @@ namespace kit
                     int x = stoi(updates[i++]);
                     int y = stoi(updates[i++]);
                     float cooldown = stof(updates[i++]);
-                    lux::City * city = this->players[team].cities[cityid];
+                    lux::City * city = &players[team].cities[cityid];
                     lux::CityTile * citytile = city->addCityTile(x, y, cooldown);
                     this->map.getCell(x, y)->citytile = citytile;
                     players[team].cityTileCount += 1;
@@ -170,14 +170,6 @@ namespace kit
     private:
         void resetPlayerStates(){
             for (int team = 0; team < 2; team++) {
-                for (auto it : players[team].cities){
-                    lux::City *city = it.second;
-                    for (auto citytile : city->citytiles) {
-                        delete citytile;
-                    }
-                    city->citytiles.clear();
-                    delete city;
-                }
                 players[team].units.clear();
                 players[team].cities.clear();
                 players[team].cityTileCount = 0;

--- a/kits/cpp/simple-transpiled/lux/map.hpp
+++ b/kits/cpp/simple-transpiled/lux/map.hpp
@@ -30,7 +30,7 @@ namespace lux
         {
             pos = Position(x, y);
         };
-        bool hasResource()
+        bool hasResource() const
         {
             return this->resource.amount > 0;
         }
@@ -40,32 +40,38 @@ namespace lux
     public:
         int width = -1;
         int height = -1;
-        vector<vector<Cell *>> map;
+        vector<vector<Cell>> map;
         GameMap(){};
-        GameMap(int width, int height)
+        GameMap(int width, int height) : width(width), height(height)
         {
-            this->width = width;
-            this->height = height;
-            map = vector<vector<Cell *>>(height, vector<Cell *>(width));
+            map = vector<vector<Cell>>(height, vector<Cell>(width));
             for (int y = 0; y < height; y++)
             {
                 for (int x = 0; x < width; x++)
                 {
-                    map[y][x] = new Cell(x, y);
+                    map[y][x] = Cell(x, y);
                 }
             }
         };
-        Cell *getCellByPos(const Position &pos) const
+        Cell const *getCellByPos(const Position &pos) const
         {
-            return this->map[pos.y][pos.x];
+            return &map[pos.y][pos.x];
         }
-        Cell *getCell(int x, int y) const
+        Cell const *getCell(int x, int y) const
         {
-            return this->map[y][x];
+            return &map[y][x];
+        }
+        Cell *getCellByPos(const Position &pos)
+        {
+            return &map[pos.y][pos.x];
+        }
+        Cell *getCell(int x, int y)
+        {
+            return &map[y][x];
         }
         void _setResource(const ResourceType &type, int x, int y, int amount)
         {
-            Cell *cell = this->getCell(x, y);
+            Cell *cell = getCell(x, y);
             cell->resource = Resource();
             cell->resource.amount = amount;
             cell->resource.type = type;

--- a/kits/cpp/simple-transpiled/main.cpp
+++ b/kits/cpp/simple-transpiled/main.cpp
@@ -76,16 +76,16 @@ int main()
           if (player.cities.size() > 0)
           {
             auto city_iter = player.cities.begin();
-            auto city = city_iter->second;
+            auto& city = city_iter->second;
 
             float closestDist = 999999;
             CityTile *closestCityTile;
-            for (auto citytile : city->citytiles)
+            for (auto& citytile : city.citytiles)
             {
-              float dist = citytile->pos.distanceTo(unit.pos);
+              float dist = citytile.pos.distanceTo(unit.pos);
               if (dist < closestDist)
               {
-                closestCityTile = citytile;
+                closestCityTile = &citytile;
                 closestDist = dist;
               }
             }

--- a/kits/cpp/simple/lux/city.hpp
+++ b/kits/cpp/simple/lux/city.hpp
@@ -52,22 +52,14 @@ namespace lux
         string cityid;
         int team;
         float fuel;
-        vector<CityTile *> citytiles;
+        vector<CityTile> citytiles{};
         float lightUpkeep;
         City(){};
-        City(int teamid, const string &cityid, float fuel, float lightUpkeep)
-        {
-            this->cityid = cityid;
-            this->team = teamid;
-            this->fuel = fuel;
-            this->citytiles = vector<CityTile *>();
-            this->lightUpkeep = lightUpkeep;
-        }
+        City(int teamid, const string &cityid, float fuel, float lightUpkeep) : cityid(cityid), team(teamid), fuel(fuel), lightUpkeep(lightUpkeep) {}
         CityTile* addCityTile(int x, int y, int cooldown)
         {
-            CityTile* ct = new CityTile(this->team, this->cityid, x, y, cooldown);
-            this->citytiles.push_back(ct);
-            return ct;
+            citytiles.emplace_back(team, cityid, x, y, cooldown);
+            return &citytiles.back();
         }
         float getLightUpkeep()
         {

--- a/kits/cpp/simple/lux/game_objects.hpp
+++ b/kits/cpp/simple/lux/game_objects.hpp
@@ -101,16 +101,11 @@ namespace lux
     public:
         int researchPoints = 0;
         int team = -1;
-        vector<Unit> units;
-        map<string, City *> cities;
+        vector<Unit> units{};
+        map<string, City> cities{};
         int cityTileCount = 0;
         Player(){};
-        Player(int team_id)
-        {
-            team = team_id;
-            cities = map<string, City *>();
-            units = vector<Unit>();
-        };
+        Player(int team_id) : team(team_id) {}
         bool researchedCoal()
         {
             return this->researchPoints >= (int)GAME_CONSTANTS["PARAMETERS"]["RESEARCH_REQUIREMENTS"]["COAL"];

--- a/kits/cpp/simple/lux/kit.hpp
+++ b/kits/cpp/simple/lux/kit.hpp
@@ -140,7 +140,7 @@ namespace kit
                     string cityid = updates[i++];
                     float fuel = stof(updates[i++]);
                     float lightUpkeep = stof(updates[i++]);
-                    this->players[team].cities[cityid] = new lux::City(team, cityid, fuel, lightUpkeep);
+                    this->players[team].cities[cityid] = lux::City(team, cityid, fuel, lightUpkeep);
                 }
                 else if (input_identifier == INPUT_CONSTANTS::CITY_TILES)
                 {
@@ -150,7 +150,7 @@ namespace kit
                     int x = stoi(updates[i++]);
                     int y = stoi(updates[i++]);
                     float cooldown = stof(updates[i++]);
-                    lux::City * city = this->players[team].cities[cityid];
+                    lux::City * city = &players[team].cities[cityid];
                     lux::CityTile * citytile = city->addCityTile(x, y, cooldown);
                     this->map.getCell(x, y)->citytile = citytile;
                     players[team].cityTileCount += 1;
@@ -170,14 +170,6 @@ namespace kit
     private:
         void resetPlayerStates(){
             for (int team = 0; team < 2; team++) {
-                for (auto it : players[team].cities){
-                    lux::City *city = it.second;
-                    for (auto citytile : city->citytiles) {
-                        delete citytile;
-                    }
-                    city->citytiles.clear();
-                    delete city;
-                }
                 players[team].units.clear();
                 players[team].cities.clear();
                 players[team].cityTileCount = 0;

--- a/kits/cpp/simple/lux/map.hpp
+++ b/kits/cpp/simple/lux/map.hpp
@@ -30,7 +30,7 @@ namespace lux
         {
             pos = Position(x, y);
         };
-        bool hasResource()
+        bool hasResource() const
         {
             return this->resource.amount > 0;
         }
@@ -40,32 +40,38 @@ namespace lux
     public:
         int width = -1;
         int height = -1;
-        vector<vector<Cell *>> map;
+        vector<vector<Cell>> map;
         GameMap(){};
-        GameMap(int width, int height)
+        GameMap(int width, int height) : width(width), height(height)
         {
-            this->width = width;
-            this->height = height;
-            map = vector<vector<Cell *>>(height, vector<Cell *>(width));
+            map = vector<vector<Cell>>(height, vector<Cell>(width));
             for (int y = 0; y < height; y++)
             {
                 for (int x = 0; x < width; x++)
                 {
-                    map[y][x] = new Cell(x, y);
+                    map[y][x] = Cell(x, y);
                 }
             }
         };
-        Cell *getCellByPos(const Position &pos) const
+        Cell const *getCellByPos(const Position &pos) const
         {
-            return this->map[pos.y][pos.x];
+            return &map[pos.y][pos.x];
         }
-        Cell *getCell(int x, int y) const
+        Cell const *getCell(int x, int y) const
         {
-            return this->map[y][x];
+            return &map[y][x];
+        }
+        Cell *getCellByPos(const Position &pos)
+        {
+            return &map[pos.y][pos.x];
+        }
+        Cell *getCell(int x, int y)
+        {
+            return &map[y][x];
         }
         void _setResource(const ResourceType &type, int x, int y, int amount)
         {
-            Cell *cell = this->getCell(x, y);
+            Cell *cell = getCell(x, y);
             cell->resource = Resource();
             cell->resource.amount = amount;
             cell->resource.type = type;

--- a/kits/cpp/simple/main.cpp
+++ b/kits/cpp/simple/main.cpp
@@ -79,16 +79,16 @@ int main()
           if (player.cities.size() > 0)
           {
             auto city_iter = player.cities.begin();
-            auto city = city_iter->second;
+            auto& city = city_iter->second;
 
             float closestDist = 999999;
             CityTile *closestCityTile;
-            for (auto citytile : city->citytiles)
+            for (auto& citytile : city.citytiles)
             {
-              float dist = citytile->pos.distanceTo(unit.pos);
+              float dist = citytile.pos.distanceTo(unit.pos);
               if (dist < closestDist)
               {
-                closestCityTile = citytile;
+                closestCityTile = &citytile;
                 closestDist = dist;
               }
             }

--- a/tests/kit.spec.ts
+++ b/tests/kit.spec.ts
@@ -79,6 +79,21 @@ describe('Test kits', () => {
     verifyCommands(cmds1, cmds2);
   }).timeout(10000);
 
+  it('should run c++', async () => {
+    let botList = [bots.js, bots.cpp];
+    const match = await luxdim.createMatch(botList, options);
+    const res = await match.run();
+
+    botList = [bots.cpp, bots.cpp];
+    const match2 = await luxdim.createMatch(botList, options);
+    const res2 = await match.run();
+    const state: LuxMatchState = match.state;
+    const state2: LuxMatchState = match.state;
+    const cmds1 = state.game.replay.data.allCommands;
+    const cmds2 = state2.game.replay.data.allCommands;
+    verifyCommands(cmds1, cmds2);
+  }).timeout(10000);
+
   it('should run python', async () => {
     let botList = [bots.js, bots.py];
     const match = await luxdim.createMatch(botList, options);


### PR DESCRIPTION
Hey, I noticed that there were still some unresolved memory issues after this thread: #89 

In particular:
1. GameMaps dynamically allocate a large number of Cells in every constructor call, but never free the Cells, resulting in a memory leak.
2. Agents allocate Cities, and Cities allocate CityTiles, but Agents are the ones who clean up everything, which makes the ownership a little confusing. This might also cause a memory leak if you re-use the Agent class multiple times (e.g. in a custom benchmarker tool) and forget to call `resetPlayerStates` at the end.

I verified 1. in valgrind. A simple solution to the problem would just be to store objects by value on the stack, rather an dynamically allocating them. Now if for some reason you really want dynamic allocation, then we could instead use the RAII pattern, e.g. with a unique_ptr, but that doesn't sound like it would be an improvement.

I just eyeballed problem 2., but I think this refactor makes sense. A simple solution is to clearly define who owns which blocks of memory, and denote ownership by using value member variables. In this PR, I've arranged it so that _Cities own CityTiles_ (and are responsible for their cleanup), and _Players own Cities_ (and are responsible for their cleanup). That way, when you call `players[team].cities.clear();` you guarantee you have cleaned up all the Citytiles as well.

Let me know if you have any feedback. If you're trying to reduce code churn in `main.cpp`, I can refactor `City::citytiles` a little bit so that it will still store pointers and require no code changes to `main.cpp`.