### PR TITLE
Fix draw text annotation parameter order in all language starter kits

### DIFF
--- a/kits/cpp/simple-transpiled/lux/annotate.hpp
+++ b/kits/cpp/simple-transpiled/lux/annotate.hpp
@@ -15,10 +15,10 @@ namespace lux {
       return "dl " + to_string(x1) + " " + to_string(y1) + " " +  to_string(x2) + " " + to_string(y2);
     };
     static string text(int x1, int y1, string message) {
-      return "dt " + to_string(x1) + " " + to_string(y1) + " 16 '" +  message + "'";
+      return "dt " + to_string(x1) + " " + to_string(y1) + " '" +  message + "' 16";
     };
     static string text(int x1, int y1, string message, int fontsize) {
-      return "dt " + to_string(x1) + " " + to_string(y1) + " " + to_string(fontsize) + " '" +  message + "'";
+      return "dt " + to_string(x1) + " " + to_string(y1) + " '" +  message + "' " + to_string(fontsize);
     };
     static string sidetext(string message) {
       return "dst '" + message + "'";

--- a/kits/cpp/simple/lux/annotate.hpp
+++ b/kits/cpp/simple/lux/annotate.hpp
@@ -15,10 +15,10 @@ namespace lux {
       return "dl " + to_string(x1) + " " + to_string(y1) + " " +  to_string(x2) + " " + to_string(y2);
     };
     static string text(int x1, int y1, string message) {
-      return "dt " + to_string(x1) + " " + to_string(y1) + " 16 '" +  message + "'";
+      return "dt " + to_string(x1) + " " + to_string(y1) + " '" +  message + "' 16";
     };
     static string text(int x1, int y1, string message, int fontsize) {
-      return "dt " + to_string(x1) + " " + to_string(y1) + " " + to_string(fontsize) + " '" +  message + "'";
+      return "dt " + to_string(x1) + " " + to_string(y1) + " '" +  message + "' " + to_string(fontsize);
     };
     static string sidetext(string message) {
       return "dst '" + message + "'";

--- a/kits/java/simple/lux/Annotate.java
+++ b/kits/java/simple/lux/Annotate.java
@@ -11,10 +11,10 @@ public class Annotate {
     return "dl " + x1 + " " + y1 + " " + x2 + " " + y2;
   }
   public static String text(int x1, int y1, String message) {
-    return "dt " + x1 + " " + y1 + " 16 '" + message + "'";
+    return "dt " + x1 + " " + y1 + " '" + message + "' 16 ";
   }
   public static String text(int x1, int y1, String message, int fontsize) {
-    return "dt " + x1 + " " + y1 +  " " + fontsize + " '" + message + "'";
+    return "dt " + x1 + " " + y1 + " '" + message + "' " + fontsize;
   }
   public static String sidetext(String message) {
     return "dst '" + message + "'";

--- a/kits/js/simple/lux/kit.js
+++ b/kits/js/simple/lux/kit.js
@@ -196,7 +196,7 @@ const annotate = {
     return `dl ${x1} ${y1} ${x2} ${y2}`
   },
   text: (x1, y1, message, fontsize = 16) => {
-    return `dt ${x1} ${y1} ${fontsize} '${message}'`
+    return `dt ${x1} ${y1} '${message}' ${fontsize}`
   },
   sidetext: (message) => {
     return `dst '${message}'`

--- a/kits/python/simple/lux/annotate.py
+++ b/kits/python/simple/lux/annotate.py
@@ -9,8 +9,8 @@ def line(x1: int, y1: int, x2: int, y2: int) -> str:
 
 # text at cell on map
 def text(x: int, y: int, message: str, fontsize: int = 16) -> str:
-    return f"dt {x} {y} {fontsize} '{message}'"
-
+    return f"dt {x} {y} '{message}' {fontsize}"
+ 
 # text besides map
 def sidetext(message: str) -> str:
     return f"dst '{message}'"

--- a/kits/ts/simple/lux/Agent.ts
+++ b/kits/ts/simple/lux/Agent.ts
@@ -212,7 +212,7 @@ export const annotate = {
     return `dl ${x1} ${y1} ${x2} ${y2}`
   },
   text: (x1: number, y1: number, message: string, fontsize: number = 16) => {
-    return `dt ${x1} ${y1} ${fontsize} '${message}'`
+    return `dt ${x1} ${y1} '${message}' ${fontsize}`
   },
   sidetext: (message: string) => {
     return `dst '${message}'`


### PR DESCRIPTION
Fixes #149 in all language starter kits.

Before this PR, the `annotate.text()` helper command silently fails due to the `fontsize` and `message` parameters being swapped.
